### PR TITLE
dynamic shell for localhost executions - mixed environments and non default ansible_connections

### DIFF
--- a/roles/s1_agent_common/tasks/main.yml
+++ b/roles/s1_agent_common/tasks/main.yml
@@ -61,3 +61,9 @@
     label: "{{ loop_vars | basename }}"
   tags:
     - always
+
+- name: Set shell type dynamically
+  delegate_to: localhost
+  run_once: true
+  set_fact:
+    dynamic_shell_type: "{{ 'sh' if ansible_system != 'Windows' else 'powershell' }}"

--- a/roles/s1_agent_download/tasks/main.yml
+++ b/roles/s1_agent_download/tasks/main.yml
@@ -57,6 +57,8 @@
   delegate_to: localhost
   run_once: true
   become: false
+  vars:
+    ansible_shell_type: "{{ dynamic_shell_type }}"
 
 - name: Show s1_agent_version
   ansible.builtin.debug:
@@ -122,6 +124,8 @@
   delegate_to: localhost
   run_once: true
   become: false
+  vars:
+    ansible_shell_type: "{{ dynamic_shell_type }}"
 
 - name: Download SentinelOne agent
   ansible.builtin.get_url:
@@ -138,3 +142,5 @@
   delay: 60 # Mgmt Console API is limited to 2 pkg downloads / 60 seconds
   delegate_to: localhost
   become: false
+  vars:
+    ansible_shell_type: "{{ dynamic_shell_type }}"


### PR DESCRIPTION
In our setup, we are using `aws_ssm` to [connect to our remote machines. ](https://docs.ansible.com/ansible/latest/collections/community/aws/aws_ssm_connection.html)
While this is no issue with linux -> linux connections, it get's tricky with linux-> windows and probably(!) vice versa (untested).

Our playbook looks like this:
```
---
- name: Install SentinelOne agent on Windows Server 
  hosts: windows
  collections:
    - sentinelone.s1agents # Reference the installed collection
  vars:
    s1_secrets: "{{ lookup('community.hashi_vault.hashi_vault', vault_path, token=hashi_vault_token, url=vault_addr)}}"
    s1_api_token: "{{ s1_secrets['api_token']}}"
    s1_agent_site_token: "{{ s1_secrets['site_token_ansible']}}"
    s1_management_console: "https://euce1-106.sentinelone.net"
    s1_install_msi: true
    s1_platform_type: windows
  tasks:

    - name: Install SentinelOne agent if not installed or outdated
      include_role:
        name: s1_agent_install

```

and our config like this:
```
ansible_connection: aws_ssm
ansible_aws_ssm_profile: my-aws-profile
ansible_aws_ssm_bucket_name: example-bucket
ansible_aws_ssm_region: eu-central-1
ansible_shell_type: powershell
ansible_become_method: runas
ansible_become_user: Administrator
```

During the step to retrieve the available agent versions via API, the step fails with:

```
FAILED - RETRYING: [i-0ad9f2a0178f2e4d6 -> localhost]: Get available SentinelOne agent packages (8 retries left).Result was: {
"attempts": 3,
"changed": false,
"module_stderr": "/bin/sh: line 1: PowerShell: command not found\n",
"module_stdout": "",
"msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
"rc": 0,
"retries": 11
}
```

This happens due to `delegate_to: localhost` [in the task](https://github.com/Sentinel-One/ansible_collection_s1agents/blob/main/roles/s1_agent_download/tasks/main.yml#L57). 

The error thrown is correct, as my linux machine does not have powershell installed.

Due to the fact, that we are using `aws_ssm`, we need to set `ansible_shell_type: powershell` to ensure the provisioning works. 

We need to override that variable for local tasks, hence we need to know our local operating system. 

This PR should add some flexibility for this scenario, without breaking anything else.
